### PR TITLE
feat: Use small request dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,12 +67,13 @@
     "presystem-test": "npm run compile"
   },
   "dependencies": {
-    "@google-cloud/common": "^0.21.0",
+    "@google-cloud/common": "^0.23.0",
     "@google-cloud/promisify": "^0.3.0",
     "arrify": "^1.0.1",
     "extend": "^3.0.1",
     "is": "^3.2.1",
-    "is-html": "^1.1.0"
+    "is-html": "^1.1.0",
+    "teeny-request": "^3.4.0"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^2.3.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import * as is from 'is';
 const isHtml = require('is-html');
 import {DecorateRequestOptions, BodyResponseCallback} from '@google-cloud/common/build/src/util';
 import * as r from 'request';
+import {teenyRequest} from 'teeny-request';
 
 const PKG = require('../../package.json');
 
@@ -148,6 +149,7 @@ export interface TranslateConfig extends GoogleAuthOptions {
   key?: string;
   autoRetry?: boolean;
   maxRetries?: number;
+  requestModule?: typeof teenyRequest;
 }
 
 /**
@@ -191,10 +193,12 @@ export class Translate extends Service {
       scopes: ['https://www.googleapis.com/auth/cloud-platform'],
       packageJson: require('../../package.json'),
       projectIdRequired: false,
+      requestModule: teenyRequest as typeof r,
     };
 
     super(config, options);
     this.options = options || {};
+    this.options.requestModule = config.requestModule;
     if (this.options.key) {
       this.key = this.options.key;
     }
@@ -544,7 +548,7 @@ export class Translate extends Service {
       },
     });
 
-    util.makeRequest(reqOpts, this.options!, callback!);
+    util.makeRequest(reqOpts, this.options, callback!);
   }
 }
 


### PR DESCRIPTION
Pass `teeny-request` to `common.Service` so we don't rely on
`request`.