### PR TITLE
fix: always run all system-tests

### DIFF
--- a/system-test/translate.ts
+++ b/system-test/translate.ts
@@ -153,8 +153,11 @@ describe('translate', () => {
     });
   });
 
-  (API_KEY ? describe : describe.skip)('authentication', () => {
+  describe('authentication', () => {
     beforeEach(() => {
+      if (!API_KEY) {
+        throw new Error('The `TRANSLATE_API_KEY` environment variable is required!');
+      }
       translate = new Translate({key: API_KEY});
     });
 


### PR DESCRIPTION
This was leading to errors in the system-tests that only surfaced when in CI, and not locally. 