### PR TITLE
fix: set request module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,7 @@ export interface TranslateConfig extends GoogleAuthOptions {
   key?: string;
   autoRetry?: boolean;
   maxRetries?: number;
-  requestModule?: typeof teenyRequest;
+  request?: typeof r;
 }
 
 /**
@@ -198,7 +198,7 @@ export class Translate extends Service {
 
     super(config, options);
     this.options = options || {};
-    this.options.requestModule = config.requestModule;
+    this.options.request = config.requestModule;
     if (this.options.key) {
       this.key = this.options.key;
     }


### PR DESCRIPTION
The field is called `request`, not `requestModule`.

Fixes: https://github.com/googleapis/nodejs-translate/issues/108
