### PR TITLE
refactor(samples): convert sample tests from ava to mocha

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -9,8 +9,7 @@
     "node": ">=8"
   },
   "scripts": {
-    "ava": "ava -T 20s --verbose test/*.test.js ./system-test/*.test.js",
-    "cover": "nyc --reporter=lcov --cache ava -T 20s --verbose test/*.test.js ./system-test/*.test.js && nyc report",
+    "cover": "nyc --reporter=lcov --cache mocha ./system-test/*.test.js --timeout=60000 && nyc report",
     "test": "npm run cover"
   },
   "dependencies": {

--- a/samples/system-test/.eslintrc.yml
+++ b/samples/system-test/.eslintrc.yml
@@ -1,4 +1,6 @@
 ---
+env:
+  mocha: true
 rules:
   node/no-unpublished-require: off
   node/no-unsupported-features: off

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -17,41 +17,36 @@
 
 const proxyquire = require(`proxyquire`).noPreserveCache();
 const sinon = require(`sinon`);
-const test = require(`ava`);
+const assert = require(`assert`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 const {Translate} = proxyquire(`@google-cloud/translate`, {});
 const translate = new Translate();
 
-test.before(tools.checkCredentials);
-test.before(tools.stubConsole);
-test.after.always(tools.restoreConsole);
+before(tools.checkCredentials);
+before(tools.stubConsole);
+after(tools.restoreConsole);
 
-test.cb(`should translate a string`, t => {
+it(`should translate a string`, () => {
   const string = `Hello, world!`;
   const expectedTranslation = `Привет, мир!`;
   const targetLanguage = `ru`;
   const translateMock = {
     translate: (_string, _targetLanguage) => {
-      t.is(_string, string);
-      t.is(_targetLanguage, targetLanguage);
+      assert.strictEqual(_string, string);
+      assert.strictEqual(_targetLanguage, targetLanguage);
 
       return translate
         .translate(_string, _targetLanguage)
-        .then(([translation]) => {
-          t.is(translation, expectedTranslation);
-
-          setTimeout(() => {
-            try {
-              t.is(console.log.callCount, 2);
-              t.deepEqual(console.log.getCall(0).args, [`Text: ${string}`]);
-              t.deepEqual(console.log.getCall(1).args, [
-                `Translation: ${expectedTranslation}`,
-              ]);
-              t.end();
-            } catch (err) {
-              t.end(err);
-            }
-          }, 200);
+        .then(async ([translation]) => {
+          assert.strictEqual(translation, expectedTranslation);
+          await new Promise(r => setTimeout(r, 200));
+          assert.strictEqual(console.log.callCount, 2);
+          assert.deepStrictEqual(console.log.getCall(0).args, [
+            `Text: ${string}`,
+          ]);
+          assert.deepStrictEqual(console.log.getCall(1).args, [
+            `Translation: ${expectedTranslation}`,
+          ]);
 
           return [translation];
         });

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -15,21 +15,21 @@
 
 'use strict';
 
-const proxyquire = require(`proxyquire`).noPreserveCache();
-const sinon = require(`sinon`);
-const assert = require(`assert`);
-const tools = require(`@google-cloud/nodejs-repo-tools`);
-const {Translate} = proxyquire(`@google-cloud/translate`, {});
+const proxyquire = require('proxyquire').noPreserveCache();
+const sinon = require('sinon');
+const assert = require('assert');
+const tools = require('@google-cloud/nodejs-repo-tools');
+const {Translate} = proxyquire('@google-cloud/translate', {});
 const translate = new Translate();
 
 before(tools.checkCredentials);
 before(tools.stubConsole);
 after(tools.restoreConsole);
 
-it(`should translate a string`, () => {
-  const string = `Hello, world!`;
-  const expectedTranslation = `Привет, мир!`;
-  const targetLanguage = `ru`;
+it('should translate a string', () => {
+  const string = 'Hello, world!';
+  const expectedTranslation = 'Привет, мир!';
+  const targetLanguage = 'ru';
   const translateMock = {
     translate: (_string, _targetLanguage) => {
       assert.strictEqual(_string, string);
@@ -53,7 +53,7 @@ it(`should translate a string`, () => {
     },
   };
 
-  proxyquire(`../quickstart`, {
+  proxyquire('../quickstart', {
     '@google-cloud/translate': {
       Translate: sinon.stub().returns(translateMock),
     },

--- a/samples/system-test/translate.test.js
+++ b/samples/system-test/translate.test.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const path = require(`path`);
-const test = require(`ava`);
+const assert = require(`assert`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 const {Translate} = require(`@google-cloud/translate`);
 const translate = new Translate();
@@ -28,16 +28,16 @@ const text2 = `Goodbye!`;
 const model = `nmt`;
 const toLang = `ru`;
 
-test.before(tools.checkCredentials);
+before(tools.checkCredentials);
 
-test(`should detect language of a single string`, async t => {
+it(`should detect language of a single string`, async () => {
   const output = await tools.runAsync(`${cmd} detect "${text}"`, cwd);
   const [detection] = await translate.detect(text);
   const expected = `Detections:\n${text} => ${detection.language}`;
-  t.is(output, expected);
+  assert.strictEqual(output, expected);
 });
 
-test(`should detect language of multiple strings`, async t => {
+it(`should detect language of multiple strings`, async () => {
   const output = await tools.runAsync(
     `${cmd} detect "${text}" "${text2}"`,
     cwd
@@ -46,32 +46,32 @@ test(`should detect language of multiple strings`, async t => {
   const expected = `Detections:\n${text} => ${
     detections[0].language
   }\n${text2} => ${detections[1].language}`;
-  t.is(output, expected);
+  assert.strictEqual(output, expected);
 });
 
-test(`should list languages`, async t => {
+it(`should list languages`, async () => {
   const output = await tools.runAsync(`${cmd} list`, cwd);
-  t.true(output.includes(`Languages:`));
-  t.true(output.includes(`{ code: 'af', name: 'Afrikaans' }`));
+  assert.ok(output.includes(`Languages:`));
+  assert.ok(output.includes(`{ code: 'af', name: 'Afrikaans' }`));
 });
 
-test(`should list languages with a target`, async t => {
+it(`should list languages with a target`, async () => {
   const output = await tools.runAsync(`${cmd} list es`, cwd);
-  t.true(output.includes(`Languages:`));
-  t.true(output.includes(`{ code: 'af', name: 'afrikáans' }`));
+  assert.ok(output.includes(`Languages:`));
+  assert.ok(output.includes(`{ code: 'af', name: 'afrikáans' }`));
 });
 
-test(`should translate a single string`, async t => {
+it(`should translate a single string`, async () => {
   const output = await tools.runAsync(
     `${cmd} translate ${toLang} "${text}"`,
     cwd
   );
   const [translation] = await translate.translate(text, toLang);
   const expected = `Translations:\n${text} => (${toLang}) ${translation}`;
-  t.is(output, expected);
+  assert.strictEqual(output, expected);
 });
 
-test(`should translate multiple strings`, async t => {
+it(`should translate multiple strings`, async () => {
   const output = await tools.runAsync(
     `${cmd} translate ${toLang} "${text}" "${text2}"`,
     cwd
@@ -80,20 +80,20 @@ test(`should translate multiple strings`, async t => {
   const expected = `Translations:\n${text} => (${toLang}) ${
     translations[0]
   }\n${text2} => (${toLang}) ${translations[1]}`;
-  t.is(output, expected);
+  assert.strictEqual(output, expected);
 });
 
-test(`should translate a single string with a model`, async t => {
+it(`should translate a single string with a model`, async () => {
   const output = await tools.runAsync(
     `${cmd} translate-with-model ${toLang} ${model} "${text}"`,
     cwd
   );
   const [translation] = await translate.translate(text, toLang);
   const expected = `Translations:\n${text} => (${toLang}) ${translation}`;
-  t.is(output, expected);
+  assert.strictEqual(output, expected);
 });
 
-test(`should translate multiple strings with a model`, async t => {
+it(`should translate multiple strings with a model`, async () => {
   const output = await tools.runAsync(
     `${cmd} translate-with-model ${toLang} ${model} "${text}" "${text2}"`,
     cwd
@@ -102,5 +102,5 @@ test(`should translate multiple strings with a model`, async t => {
   const expected = `Translations:\n${text} => (${toLang}) ${
     translations[0]
   }\n${text2} => (${toLang}) ${translations[1]}`;
-  t.is(output, expected);
+  assert.strictEqual(output, expected);
 });

--- a/samples/system-test/translate.test.js
+++ b/samples/system-test/translate.test.js
@@ -15,29 +15,29 @@
 
 'use strict';
 
-const path = require(`path`);
-const assert = require(`assert`);
-const tools = require(`@google-cloud/nodejs-repo-tools`);
-const {Translate} = require(`@google-cloud/translate`);
+const path = require('path');
+const assert = require('assert');
+const tools = require('@google-cloud/nodejs-repo-tools');
+const {Translate} = require('@google-cloud/translate');
 const translate = new Translate();
 
-const cwd = path.join(__dirname, `..`);
-const cmd = `node translate.js`;
-const text = `Hello world!`;
-const text2 = `Goodbye!`;
-const model = `nmt`;
-const toLang = `ru`;
+const cwd = path.join(__dirname, '..');
+const cmd = 'node translate.js';
+const text = 'Hello world!';
+const text2 = 'Goodbye!';
+const model = 'nmt';
+const toLang = 'ru';
 
 before(tools.checkCredentials);
 
-it(`should detect language of a single string`, async () => {
+it('should detect language of a single string', async () => {
   const output = await tools.runAsync(`${cmd} detect "${text}"`, cwd);
   const [detection] = await translate.detect(text);
   const expected = `Detections:\n${text} => ${detection.language}`;
   assert.strictEqual(output, expected);
 });
 
-it(`should detect language of multiple strings`, async () => {
+it('should detect language of multiple strings', async () => {
   const output = await tools.runAsync(
     `${cmd} detect "${text}" "${text2}"`,
     cwd
@@ -49,19 +49,19 @@ it(`should detect language of multiple strings`, async () => {
   assert.strictEqual(output, expected);
 });
 
-it(`should list languages`, async () => {
+it('should list languages', async () => {
   const output = await tools.runAsync(`${cmd} list`, cwd);
-  assert.ok(output.includes(`Languages:`));
+  assert.ok(output.includes('Languages:'));
   assert.ok(output.includes(`{ code: 'af', name: 'Afrikaans' }`));
 });
 
-it(`should list languages with a target`, async () => {
+it('should list languages with a target', async () => {
   const output = await tools.runAsync(`${cmd} list es`, cwd);
-  assert.ok(output.includes(`Languages:`));
+  assert.ok(output.includes('Languages:'));
   assert.ok(output.includes(`{ code: 'af', name: 'afrikáans' }`));
 });
 
-it(`should translate a single string`, async () => {
+it('should translate a single string', async () => {
   const output = await tools.runAsync(
     `${cmd} translate ${toLang} "${text}"`,
     cwd
@@ -71,7 +71,7 @@ it(`should translate a single string`, async () => {
   assert.strictEqual(output, expected);
 });
 
-it(`should translate multiple strings`, async () => {
+it('should translate multiple strings', async () => {
   const output = await tools.runAsync(
     `${cmd} translate ${toLang} "${text}" "${text2}"`,
     cwd
@@ -83,7 +83,7 @@ it(`should translate multiple strings`, async () => {
   assert.strictEqual(output, expected);
 });
 
-it(`should translate a single string with a model`, async () => {
+it('should translate a single string with a model', async () => {
   const output = await tools.runAsync(
     `${cmd} translate-with-model ${toLang} ${model} "${text}"`,
     cwd
@@ -93,7 +93,7 @@ it(`should translate a single string with a model`, async () => {
   assert.strictEqual(output, expected);
 });
 
-it(`should translate multiple strings with a model`, async () => {
+it('should translate multiple strings with a model', async () => {
   const output = await tools.runAsync(
     `${cmd} translate-with-model ${toLang} ${model} "${text}" "${text2}"`,
     cwd


### PR DESCRIPTION
Fixes convert all sample tests from ava to mocha [#2865](https://github.com/googleapis/google-cloud-node/issues/2865) (it's a good idea to open an issue first for discussion)

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
