### PR TITLE
Change region tag to translate_translate_text_with_glossary_beta

### DIFF
--- a/samples/v3beta1/translate_translate_text_with_glossary_beta.js
+++ b/samples/v3beta1/translate_translate_text_with_glossary_beta.js
@@ -21,7 +21,7 @@ function main(
   glossaryId = 'glossary',
   text = 'text to translate'
 ) {
-  // [START translate_text_with_glossary_beta]
+  // [START translate_translate_text_with_glossary_beta]
   /**
    * TODO(developer): Uncomment these variables before running the sample.
    */
@@ -61,7 +61,7 @@ function main(
   }
 
   translateTextWithGlossary();
-  // [END translate_text_with_glossary_beta]
+  // [END translate_translate_text_with_glossary_beta]
 }
 
 main(...process.argv.slice(2));


### PR DESCRIPTION
Update region tag to `translate_translate_text_with_glossary_beta`

The file name & `REGION_TAG` in the test are already using this.

Only the START/END comments weren't using this.