### PR TITLE
docs(samples): fix translate with glossary sample

### DIFF
--- a/samples/test/v3beta1/translate_translate_text_with_glossary_beta.test.js
+++ b/samples/test/v3beta1/translate_translate_text_with_glossary_beta.test.js
@@ -64,7 +64,7 @@ describe(REGION_TAG, () => {
     const output = execSync(
       `node v3beta1/${REGION_TAG}.js ${projectId} ${location} ${glossaryId} ${input}`
     );
-    assert.match(output, /direcciones/);
+    assert.match(output, /indicaciones/);
   });
 
   after(async function() {

--- a/samples/v3beta1/translate_translate_text_with_glossary_beta.js
+++ b/samples/v3beta1/translate_translate_text_with_glossary_beta.js
@@ -55,7 +55,7 @@ function main(
     // Run request
     const [response] = await translationClient.translateText(request);
 
-    for (const translation of response.translations) {
+    for (const translation of response.glossaryTranslations) {
       console.log(`Translation: ${translation.translatedText}`);
     }
   }


### PR DESCRIPTION
Translation results from glossaries are in a different collection
(glossary_translations rather than translations)

The test wasn't checking that the result matched the translation term from the glossary (fixed test, updated code to pass)

Glossary CSV for this test: https://storage.googleapis.com/cloud-samples-data/translation/glossary.csv