### PR TITLE
fix: removed display_name from sample

### DIFF
--- a/samples/v3/translate_get_supported_languages.js
+++ b/samples/v3/translate_get_supported_languages.js
@@ -42,9 +42,6 @@ function main(projectId = 'YOUR_PROJECT_ID', location = 'global') {
       // example, 'en', 'ja'. In certain cases, BCP-47 codes including language and
       // region identifiers are returned (for example, 'zh-TW' and 'zh-CN')
       console.log(`Language - Language Code: ${language.languageCode}`);
-      // Human readable name of the language localized in the display language specified
-      // in the request.
-      console.log(`Language - Display Name: ${language.displayName}`);
       // Can be used as source language.
       console.log(`Language - Support Source: ${language.supportSource}`);
       // Can be used as target language.


### PR DESCRIPTION
fixes [b/145643448](url)

translate_get_supported_languages.js is not intended to show displayName, however, there is a print statement that is expecting it. I removed the print statement, as this feature is intended to be showcased in translate_get_supported_languages_for_target.js