### PR TITLE
chore: Updated the Readme to account for the required key

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ npm install @google-cloud/translate
   const {Translate} = require('@google-cloud/translate').v2;
 
   // Instantiates a client
-  const translate = new Translate({projectId});
+  const translate = new Translate({
+   projectId: // Project ID
+   key: // GOOGLE_API_KEY HERE
+  });
 
   async function quickStart() {
     // The text to translate


### PR DESCRIPTION
Description

I was making use of the library and found out that the `key` was a required field but was not specified on the docs. This drove me to look into the source code for the library and figure out what was required, decided to help someone else who might fall into the same issue.

Hence this PR 🙂