### PR TITLE
samples: fix broken test

### DIFF
--- a/samples/test/v3beta1/translate_list_glossary_beta.test.js
+++ b/samples/test/v3beta1/translate_list_glossary_beta.test.js
@@ -18,6 +18,7 @@ const {assert} = require('chai');
 const {describe, it, before, after} = require('mocha');
 const {TranslationServiceClient} = require('@google-cloud/translate').v3beta1;
 const cp = require('child_process');
+const uuid = require('uuid');
 
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
@@ -26,7 +27,7 @@ const REGION_TAG = 'translate_list_glossary_beta';
 describe(REGION_TAG, () => {
   const translationClient = new TranslationServiceClient();
   const location = 'us-central1';
-  const glossaryId = 'test-glossary';
+  const glossaryId = `test-glossary_${uuid.v4()}`;
 
   before(async () => {
     // Add a glossary to be deleted


### PR DESCRIPTION


Fixes #560 🦕

context: batch translate sample usually fluctuates 2-4min (rarely 4min).

python sample has extended timeout for batch_Translate exclusively.

https://github.com/GoogleCloudPlatform/python-docs-samples/blob/4a251779251da3f1a114318c374b1458f6479025/translate/cloud-client/translate_v3_batch_translate_text_with_glossary_test.py#L76

If there is other way to set timeout only on batch translate test, please advice on that

