### PR TITLE
samples: translate --> fixes timeout issue

### DIFF
--- a/samples/test/v3/translate_batch_translate_text_with_glossary_and_model.test.js
+++ b/samples/test/v3/translate_batch_translate_text_with_glossary_and_model.test.js
@@ -86,7 +86,6 @@ describe(REGION_TAG, () => {
 
     // batch translate fluctuates between 2 to 4 minutes.
     this.timeout(300000);
-    this.timeout(150000);
   });
 
   // Delete the folder from GCS for cleanup

--- a/samples/test/v3/translate_batch_translate_text_with_glossary_and_model.test.js
+++ b/samples/test/v3/translate_batch_translate_text_with_glossary_and_model.test.js
@@ -14,14 +14,14 @@
 
 'use strict';
 
-const {assert} = require('chai');
-const {describe, it, before, after} = require('mocha');
-const {TranslationServiceClient} = require('@google-cloud/translate');
-const {Storage} = require('@google-cloud/storage');
+const { assert } = require('chai');
+const { describe, it, before, after } = require('mocha');
+const { TranslationServiceClient } = require('@google-cloud/translate');
+const { Storage } = require('@google-cloud/storage');
 const cp = require('child_process');
 const uuid = require('uuid');
 
-const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+const execSync = cmd => cp.execSync(cmd, { encoding: 'utf-8' });
 
 const REGION_TAG = 'translate_batch_translate_text_with_glossary_and_model';
 
@@ -85,7 +85,8 @@ describe(REGION_TAG, () => {
     assert.match(output, /Translated Characters: 25/);
 
     // batch translate fluctuates between 2 to 4 minutes.
-    this.timeout(30000);
+    this.timeout(300000);
+    this.timeout(150000);
   });
 
   // Delete the folder from GCS for cleanup

--- a/samples/test/v3/translate_batch_translate_text_with_glossary_and_model.test.js
+++ b/samples/test/v3/translate_batch_translate_text_with_glossary_and_model.test.js
@@ -14,14 +14,14 @@
 
 'use strict';
 
-const { assert } = require('chai');
-const { describe, it, before, after } = require('mocha');
-const { TranslationServiceClient } = require('@google-cloud/translate');
-const { Storage } = require('@google-cloud/storage');
+const {assert} = require('chai');
+const {describe, it, before, after} = require('mocha');
+const {TranslationServiceClient} = require('@google-cloud/translate');
+const {Storage} = require('@google-cloud/storage');
 const cp = require('child_process');
 const uuid = require('uuid');
 
-const execSync = cmd => cp.execSync(cmd, { encoding: 'utf-8' });
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const REGION_TAG = 'translate_batch_translate_text_with_glossary_and_model';
 

--- a/samples/test/v3/translate_batch_translate_text_with_glossary_and_model.test.js
+++ b/samples/test/v3/translate_batch_translate_text_with_glossary_and_model.test.js
@@ -14,14 +14,14 @@
 
 'use strict';
 
-const {assert} = require('chai');
-const {describe, it, before, after} = require('mocha');
-const {TranslationServiceClient} = require('@google-cloud/translate');
-const {Storage} = require('@google-cloud/storage');
+const { assert } = require('chai');
+const { describe, it, before, after } = require('mocha');
+const { TranslationServiceClient } = require('@google-cloud/translate');
+const { Storage } = require('@google-cloud/storage');
 const cp = require('child_process');
 const uuid = require('uuid');
 
-const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+const execSync = cmd => cp.execSync(cmd, { encoding: 'utf-8' });
 
 const REGION_TAG = 'translate_batch_translate_text_with_glossary_and_model';
 
@@ -72,7 +72,7 @@ describe(REGION_TAG, () => {
     await operation.promise();
   });
 
-  it('should batch translate the input text with a glossary', async () => {
+  it('should batch translate the input text with a glossary', async function () {
     const projectId = await translationClient.getProjectId();
     const inputUri =
       'gs://cloud-samples-data/translation/text_with_custom_model_and_glossary.txt';
@@ -83,6 +83,9 @@ describe(REGION_TAG, () => {
     );
     assert.match(output, /Total Characters: 25/);
     assert.match(output, /Translated Characters: 25/);
+
+    // batch translate fluctuates between 2 to 4 minutes.
+    this.timeout(30000);
   });
 
   // Delete the folder from GCS for cleanup


### PR DESCRIPTION
Fixes #560 🦕

context: batch translate sample usually fluctuates 2-4min (rarely 4min).

python sample has extended timeout for batch_Translate exclusively.

https://github.com/GoogleCloudPlatform/python-docs-samples/blob/4a251779251da3f1a114318c374b1458f6479025/translate/cloud-client/translate_v3_batch_translate_text_with_glossary_test.py#L76

I hope i am doing it right (setting exclusive timeout on batch_Translate)
