### PR TITLE
test: replace 'after' hook with 'afterEach' to ensure directory deletion

### DIFF
--- a/samples/test/v3/translate_batch_translate_text_with_model.test.js
+++ b/samples/test/v3/translate_batch_translate_text_with_model.test.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const {assert} = require('chai');
-const {describe, it, before, after} = require('mocha');
+const {describe, it, before, afterEach} = require('mocha');
 const {TranslationServiceClient} = require('@google-cloud/translate');
 const {Storage} = require('@google-cloud/storage');
 const cp = require('child_process');
@@ -80,7 +80,7 @@ describe(REGION_TAG, () => {
   });
 
   // Delete the folder from GCS for cleanup
-  after(async () => {
+  afterEach(async () => {
     const projectId = await translationClient.getProjectId();
     const options = {
       prefix: `translation-${bucketUuid}`,

--- a/samples/test/v3beta1/translate_batch_translate_document.test.js
+++ b/samples/test/v3beta1/translate_batch_translate_document.test.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const {assert} = require('chai');
-const {describe, it, before, after} = require('mocha');
+const {describe, it, before, afterEach} = require('mocha');
 const {TranslationServiceClient} = require('@google-cloud/translate').v3beta1;
 const {Storage} = require('@google-cloud/storage');
 const cp = require('child_process');
@@ -65,7 +65,7 @@ describe(REGION_TAG, () => {
   });
 
   // Delete the folder from GCS for cleanup
-  after(async () => {
+  afterEach(async () => {
     const projectId = await translationClient.getProjectId();
     const options = {
       prefix: `translation-${bucketUuid}`,

--- a/samples/test/v3beta1/translate_batch_translate_text_beta.test.js
+++ b/samples/test/v3beta1/translate_batch_translate_text_beta.test.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const {assert} = require('chai');
-const {describe, it, before, after} = require('mocha');
+const {describe, it, before, afterEach} = require('mocha');
 const {TranslationServiceClient} = require('@google-cloud/translate').v3beta1;
 const {Storage} = require('@google-cloud/storage');
 const cp = require('child_process');
@@ -66,7 +66,7 @@ describe(REGION_TAG, () => {
   });
 
   // Delete the folder from GCS for cleanup
-  after(async () => {
+  afterEach(async () => {
     const projectId = await translationClient.getProjectId();
     const options = {
       prefix: `translation-${bucketUuid}`,


### PR DESCRIPTION
Replacing the `after` hook with `afterEach` ensures that the output directory is deleted before each retry.

Change-Id: Ia9323762e3c68916217fc734df1df485c9b0e83c

Fixes #727 , #728 , #733  🦕
